### PR TITLE
Reuse same instance of JDTServicesManager and disable test hover

### DIFF
--- a/jakarta-eclipse/src/org/jakarta/jdt/JDTServicesManager.java
+++ b/jakarta-eclipse/src/org/jakarta/jdt/JDTServicesManager.java
@@ -8,30 +8,36 @@ import org.eclipse.jdt.core.ICompilationUnit;
 import org.eclipse.jdt.core.IType;
 import org.eclipse.jdt.core.JavaModelException;
 import org.eclipse.jdt.internal.core.JavaProject;
-import org.eclipse.jdt.core.IMethod;
-import org.eclipse.jdt.core.ISourceRange;
 import org.eclipse.lsp4j.Diagnostic;
 import org.eclipse.lsp4j.PublishDiagnosticsParams;
-import org.eclipse.lsp4j.Range;
-import org.jakarta.jdt.JDTUtils;
 import org.jakarta.lsp4e.Activator;
-
-import org.jakarta.jdt.DiagnosticsCollector;
-import org.jakarta.jdt.ServletDiagnosticsCollector;
 
 import io.microshed.jakartals.commons.JakartaDiagnosticsParams;
 
 /**
- * JDT service manager.
+ * JDT manager for Java files
  *
  */
-
 public class JDTServicesManager {
+
 	private List<DiagnosticsCollector> diagnosticsCollectors = new ArrayList<>();
+
+	private static final JDTServicesManager INSTANCE = new JDTServicesManager();
+
+	public static JDTServicesManager getInstance() {
+		return INSTANCE;
+	}
+
 	public JDTServicesManager() {
 		diagnosticsCollectors.add(new ServletDiagnosticsCollector());
 	}
 
+	/**
+	 * Returns diagnostics for the given uris from the JakartaDiagnosticsParams.
+	 * 
+	 * @param javaParams the diagnostics parameters
+	 * @return diagnostics
+	 */
 	public List<PublishDiagnosticsParams> getJavaDiagnostics(JakartaDiagnosticsParams javaParams) {
 		List<PublishDiagnosticsParams> publishDiagnostics = new ArrayList<PublishDiagnosticsParams>();
 		List<Diagnostic> diagnostics = new ArrayList<>();

--- a/jakarta-eclipse/src/org/jakarta/lsp4e/JakartaLanguageClient.java
+++ b/jakarta-eclipse/src/org/jakarta/lsp4e/JakartaLanguageClient.java
@@ -39,15 +39,16 @@ public class JakartaLanguageClient extends LanguageClientImpl implements Jakarta
 
 	@Override
 	public CompletableFuture<Hover> getJavaHover(HoverParams params) {
+		return CompletableFuture.completedFuture(null);
 		// return dummy test hover object
-		return CompletableFutures.computeAsync((cancelChecker) -> {
-			IProgressMonitor monitor = getProgressMonitor(cancelChecker);
-			Hover testHover = new Hover();
-			List<Either<String, MarkedString>> contents = new ArrayList<>();
-			contents.add(Either.forLeft("this is test hover"));
-			testHover.setContents(contents);
-			return testHover;
-		});
+//		return CompletableFutures.computeAsync((cancelChecker) -> {
+//			IProgressMonitor monitor = getProgressMonitor(cancelChecker);
+//			Hover testHover = new Hover();
+//			List<Either<String, MarkedString>> contents = new ArrayList<>();
+//			contents.add(Either.forLeft("this is test hover"));
+//			testHover.setContents(contents);
+//			return testHover;
+//		});
 	}
 
 	@Override
@@ -58,9 +59,8 @@ public class JakartaLanguageClient extends LanguageClientImpl implements Jakarta
 		return CompletableFutures.computeAsync((cancelChecker) -> {
 			IProgressMonitor monitor = getProgressMonitor(cancelChecker);
 
-			JDTServicesManager manager = new JDTServicesManager();
 			List<PublishDiagnosticsParams> publishDiagnostics = new ArrayList<PublishDiagnosticsParams>();
-			publishDiagnostics = manager.getJavaDiagnostics(javaParams);
+			publishDiagnostics = JDTServicesManager.getInstance().getJavaDiagnostics(javaParams);
 			return publishDiagnostics;
 		});
 	}
@@ -75,8 +75,7 @@ public class JakartaLanguageClient extends LanguageClientImpl implements Jakarta
  	@Override
  	public CompletableFuture<List<String>> getContextBasedFilter(String uri, List<String> snippetContexts) {
  		return CompletableFutures.computeAsync((cancelChecker) -> {
- 			JDTServicesManager manager = new JDTServicesManager();
- 			return manager.getExistingContextsFromClassPath(uri, snippetContexts);
+ 			return JDTServicesManager.getInstance().getExistingContextsFromClassPath(uri, snippetContexts);
  		});
  	}
 }


### PR DESCRIPTION
- Minor formatting
- reuse the same instance of `JDTServicesManager` 
- disable test hover

Signed-off-by: Kathryn Kodama <kathryn.s.kodama@gmail.com>