### PR TITLE
Added Bean validation @Email snippet

### DIFF
--- a/jakarta.ls/src/main/java/io/microshed/jakartals/commons/JakartaEESnippetRegistryLoader.java
+++ b/jakarta.ls/src/main/java/io/microshed/jakartals/commons/JakartaEESnippetRegistryLoader.java
@@ -15,6 +15,8 @@ public class JakartaEESnippetRegistryLoader implements ISnippetRegistryLoader {
 		registry.registerSnippets(JakartaEESnippetRegistryLoader.class.getClassLoader().getResourceAsStream("jax-rs.json"), SnippetContextForJava.TYPE_ADAPTER);
 		registry.registerSnippets(JakartaEESnippetRegistryLoader.class.getClassLoader().getResourceAsStream("servlet.json"), SnippetContextForJava.TYPE_ADAPTER);
 		registry.registerSnippets(JakartaEESnippetRegistryLoader.class.getClassLoader().getResourceAsStream("persistence.json"), SnippetContextForJava.TYPE_ADAPTER);
+		registry.registerSnippets(JakartaEESnippetRegistryLoader.class.getClassLoader().getResourceAsStream("bean-validation.json"), SnippetContextForJava.TYPE_ADAPTER);
+
 	}
     
 }

--- a/jakarta.ls/src/main/resources/bean-validation.json
+++ b/jakarta.ls/src/main/resources/bean-validation.json
@@ -1,11 +1,11 @@
 {
-    "@Email string field containing an email address": {
-      "prefix": "beanvalidationemail",
+    "@Email": {
+      "prefix": "@Email",
       "body": [
         "@Email",
         "\tprivate String emailAddress;"
       ],
-      "description": "Bean Validation Constraint on Email string field",
+      "description": "Denotes an email address constraint, which validates a well-formed email address.",
       "context": {
         "type": "jakarta.validation.constraints.Email"
       }

--- a/jakarta.ls/src/main/resources/bean-validation.json
+++ b/jakarta.ls/src/main/resources/bean-validation.json
@@ -1,0 +1,13 @@
+{
+    "@Email string field containing an email address": {
+      "prefix": "beanvalidationemail",
+      "body": [
+        "@Email",
+        "\tprivate String emailAddress;"
+      ],
+      "description": "Bean Validation Constraint on Email string field",
+      "context": {
+        "type": "jakarta.validation.constraints.Email"
+      }
+    }
+  }


### PR DESCRIPTION
Bean validation email string field snippet on the @Email built-in constraint annotation.
[https://jakarta.ee/specifications/bean-validation/3.0/jakarta-bean-validation-spec-3.0.html#builtinconstraints-email](https://jakarta.ee/specifications/bean-validation/3.0/jakarta-bean-validation-spec-3.0.html#builtinconstraints-email)